### PR TITLE
fix(announcer): send to IRC via Anope 2.1 JSON-RPC

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -21,8 +21,11 @@ prometheus.slow_request_threshold = 1.5
 # Secrets
 # Set this to your GitHub webhook security token.
 # github_secret =
-# Set this to your XMLRPC server proxy URL.
-# xml_proxy =
+# Anope 2.1 JSON-RPC endpoint + bearer token (replaces the removed XML-RPC).
+# rpc_proxy = http://127.0.0.1:6080/jsonrpc
+# rpc_token =
+# rpc_devproxy = http://irc.fuelrats.dev:6080/jsonrpc
+# rpc_devtoken =
 
 # By default, the toolbar only appears for clients from IP addresses
 # '127.0.0.1' and '::1'.

--- a/jiraannouncer/utils.py
+++ b/jiraannouncer/utils.py
@@ -1,10 +1,11 @@
+import base64
 import logging
 import graypy
 import pickle
 import re
 import sys
 import time
-from xmlrpc.client import ServerProxy, Error
+import requests
 from .models.usagelog import UsageLog
 from pyramid import threadlocal
 
@@ -56,27 +57,44 @@ def demarkdown(string):
 
 
 def send(channel, message, msgshort, request):
-    """Send resulting message to IRC over XMLRPC."""
+    """Send resulting message to IRC via Anope JSON-RPC (BotServ SAY)."""
     message = message.replace('\n', ' ').replace('\r', '')
     print(f"Host: {request.host} host URL: {request.host_url}")
     if '.dev' in request.host:
-        serverurl = request.registry.settings['xml_devproxy']
+        serverurl = request.registry.settings['rpc_devproxy']
+        token = request.registry.settings['rpc_devtoken']
     else:
-        serverurl = request.registry.settings['xml_proxy']
+        serverurl = request.registry.settings['rpc_proxy']
+        token = request.registry.settings['rpc_token']
     print(f"Proxy: {serverurl}")
-    proxy = ServerProxy(serverurl)
+    # Anope 2.1 expects the raw token base64-encoded in a Bearer header.
+    headers = {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + base64.b64encode(token.encode()).decode(),
+    }
     try:
         messagesplit = [message[i:i + 475]
                         for i in range(0, len(message), 475)]
         for msgpart in messagesplit:
             log.debug(f"Sending to {channel}...")
-            log.debug(proxy.command("botserv", "ABish",
-                                    f"say {channel} {msgpart}"))
+            payload = {
+                'jsonrpc': '2.0',
+                'method': 'anope.command',
+                'params': ['ABish', 'BotServ', f'say {channel} {msgpart}'],
+                'id': 1,
+            }
+            response = requests.post(serverurl, json=payload, headers=headers,
+                                     timeout=10)
+            response.raise_for_status()
+            log.debug(response.text)
+            result = response.json()
+            if result.get('error'):
+                log.critical("ERROR" + str(result['error']))
             time.sleep(0.5)
         pickle.dump(msgshort, open("lastmessage.p", "wb"))
-    except Error as err:
+    except requests.RequestException as err:
         log.critical("ERROR" + str(err))
-    except:
+    except Exception:
         log.critical("Error sending message")
         log.critical(sys.exc_info())
         return

--- a/production.ini
+++ b/production.ini
@@ -23,8 +23,11 @@ prometheus.slow_request_threshold = 1.5
 # Secrets
 # Set this to your GitHub webhook security token.
 # github_secret =
-# Set this to your XMLRPC server proxy URL.
-# xml_proxy =
+# Anope 2.1 JSON-RPC endpoint + bearer token (replaces the removed XML-RPC).
+# rpc_proxy = http://127.0.0.1:6080/jsonrpc
+# rpc_token =
+# rpc_devproxy = http://irc.fuelrats.dev:6080/jsonrpc
+# rpc_devtoken =
 
 [server:main]
 use = egg:waitress#main


### PR DESCRIPTION
The announcer reached IRC by calling BotServ over Anope XML-RPC (`xmlrpc.client.ServerProxy.command("botserv", "ABish", "say ...")`). Anope 2.1 **removed XML-RPC** in favour of JSON-RPC, so IRC announcements broke after the mozzarella 2.0→2.1 upgrade.

## Change
- `send()` now POSTs `anope.command` to the Anope 2.1 JSON-RPC endpoint with a base64 bearer token, params `["ABish", "BotServ", "say <channel> <msg>"]` (the 2.1 param order is `[user, service, command]`).
- Config keys: `xml_proxy`/`xml_devproxy` → `rpc_proxy`+`rpc_token` / `rpc_devproxy`+`rpc_devtoken`. Endpoint is `http://<host>:6080/jsonrpc`.
- Uses the already-declared `requests` dependency instead of `xmlrpc.client`.

Real values live in the untracked `run.ini` on the server (already updated); the tracked `*.ini` show the new placeholder keys.

## Verified
Live on mozzarella against Anope 2.1.26: `send()` to `#announcerdev` produced `OVERRIDE: ABish used SAY on #announcerdev to say: ...` in the Anope log; `fr-announcer` restarted clean.